### PR TITLE
used base image without vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim
+FROM python:3.12-alpine
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
As `python:3.11-slim` image has high security vulnerabilities, this PR changes the base image in the Dockerfile to use a base image, `python:3.12-alpine`, where those vulnerabilities had been fixed.

More info on the image vulberabilities can be found [here](https://hub.docker.com/layers/library/python/3.11-slim/images/sha256-6310ad99788c86b074f6277f2199636da09e0d3c25b176d4e58ab7c6d1fe110e)